### PR TITLE
Include openssl utility in centos 7

### DIFF
--- a/Dockerfile.centos-7.ansible-latest
+++ b/Dockerfile.centos-7.ansible-latest
@@ -14,7 +14,7 @@ rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 # Install Ansible
 RUN yum groupinstall -y "development tools"
-RUN yum -y install epel-release git sudo python-devel python-setuptools python-crypto openssl-devel
+RUN yum -y install epel-release git sudo python-devel python-setuptools python-crypto openssl-devel openssl
 RUN easy_install pip
 RUN pip install httplib2 ansible
 


### PR DESCRIPTION
This fixes the issue found here:
https://github.com/CyVerse-Ansible/ansible-tls-cert/blob/master/.travis.yml#L13

I encountered the error when I tried to run the tls-cert playbook on centos-7:
```
TASK [role_under_test : Self-signed certificate and private key created] *******
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "openssl req -config /etc/ansible/roles/role_under_test/build/openssl-req.cnf -newkey rsa:2048 -x509 -nodes -day
s 3650 -keyout /etc/pki/tls/private/be71cb79afd4.key -out /etc/pki/tls/certs/be71cb79afd4.crt", "msg": "[Errno 2] No such file or directory", "rc": 2}
```

When I tried to run that `openssl` command w/o ansible in the container:
```
sudo docker exec test_dummy openssl req -config /etc/ansible/roles/role_under_test/build/openssl-req.cnf -newkey
 rsa:2048 -x509 -nodes -days 3650 -keyout /etc/pki/tls/private/be71cb79afd4.key -out /etc/pki/tls/certs/be71cb79afd4.crt
Cannot run exec command 6c32d695e811645065c24968695dde80701a528b0a82eee2a7b1a8e5bbbf663c in container be71cb79afd462e5d0595a591597cb90af595536fcfbae2431adf349c5f35a73: [
8] System error: exec: "openssl": executable file not found in $PATH
Error starting exec command in container 6c32d695e811645065c24968695dde80701a528b0a82eee2a7b1a8e5bbbf663c: Cannot run exec command 6c32d695e811645065c24968695dde80701a52
8b0a82eee2a7b1a8e5bbbf663c in container be71cb79afd462e5d0595a591597cb90af595536fcfbae2431adf349c5f35a73: [8] System error: exec: "openssl": executable file not found in
 $PATH
```
It was obvious that `openssl` was missing.
A yum install of `openssl` fixed the ansible install. We could move the install into the ansible role, but I feel like it is pretty reasonable to expect an environment to include this utility.